### PR TITLE
fix: read inventory file properly

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory       = ./inventory
+ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}


### PR DESCRIPTION
localhost was used only because this was the default behavior of ansible when it didn't find inventory file. I added `ansible.cfg` file to force read proper inventory resulting in no more warning during ansible run.

I also added a better `ansible_managed` definition.